### PR TITLE
Relax bounds for GHC 9.6

### DIFF
--- a/friendly.cabal
+++ b/friendly.cabal
@@ -31,7 +31,7 @@ source-repository head
 
 executable friendly
   main-is:             Main.hs
-  build-depends:       base                 >= 4.7  && < 4.17
+  build-depends:       base                 >= 4.7  && < 4.19
                      , bifunctors           >= 4.2  && < 5.6
                      , optparse-applicative >= 0.11 && < 0.18
   hs-source-dirs:      src


### PR DESCRIPTION
There's now one redundant import, but I figured leaving it is better than introducing CPP